### PR TITLE
Update axios.js

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
-export default axios.create({
+const instance = axios.create({
     baseURL: 'http://localhost:3500'
 });
+
+export default instance;


### PR DESCRIPTION
In this refactoring, we create an instance of `axios` with the base URL set to `http://localhost:3500`, and store it in a constant called `instance`. Finally, we export this constant as the default value of the module.

This refactoring makes the code more readable and less prone to errors. In addition, it uses the default `axios` functions to create the instance, rather than relying on a custom file, making it easy to update your code in the future if the library or instance configuration is changed.