### PR TITLE
Matching Password PR

### DIFF
--- a/src/Register.js
+++ b/src/Register.js
@@ -154,7 +154,7 @@ const Register = () => {
                             type="password"
                             id="confirm_pwd"
                             onChange={(e) => setMatchPwd(e.target.value)}
-                            value={matchPwd}
+                        
                             required
                             aria-invalid={validMatch ? "false" : "true"}
                             aria-describedby="confirmnote"


### PR DESCRIPTION
This PR seeks to remove the matching password input field bug where the value attribute is set to **{matchPwd}** which is a boolean and does  not allow one to type a matching password.